### PR TITLE
wrong API link given

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The Namegame
 
-Leading scientists have proven, via science, that learning your coworkers names while starting a new job is useful. Your test project is make it happen! We have a simple version hosted at [namegame.willowtreemobile.com](http://namegame.willowtreemobile.com/) which you can test. The api is located at [namegame.willowtreemobile.com:2000](http://namegame.willowtreemobile.com:2000).
+Leading scientists have proven, via science, that learning your coworkers names while starting a new job is useful. Your test project is make it happen! We have a simple version hosted at [namegame.willowtreemobile.com](http://namegame.willowtreemobile.com/) which you can test. The api is located at [namegame.willowtreemobile.com/api/game:2000](http://namegame.willowtreemobile.com/api/game).
 
 ## Option 1
 


### PR DESCRIPTION
Project actually uses this API: http://namegame.willowtreemobile.com/api/game which has the `pool` object. Given Current given link is http://api.namegame.willowtreemobile.com/ (dump of all names)